### PR TITLE
use phpuntit 9.2 due to compatibility with phpunit-retry-annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "keboola/php-file-storage-utils": "^0.2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.4.*",
+        "phpunit/phpunit": "9.2.*",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.1",


### PR DESCRIPTION
Error : Call to undefined method PHPUnit\Util\Xml::loadFile()
 /code/vendor/bshaffer/phpunit-retry-annotations/src/Util/Config.php:34
 /code/vendor/bshaffer/phpunit-retry-annotations/src/Util/Config.php:29

Moved in version 9.3:
https://github.com/sebastianbergmann/phpunit/commit/c331d28ac385f3286d707c74a2eb39012807dadc